### PR TITLE
[CSM-63] java.lang.NoSuchMethodError: org.slf4j.helpers

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -55,7 +55,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
-			<version>1.5.6</version>
+			<version>1.6.2</version>
 		</dependency>
 
 		<!-- Begin OpenMRS core -->


### PR DESCRIPTION
clearing version mis-match between the various SLF4J API and integration libraries, 
making 1.6.x in both pom files solved the issue reported at: https://issues.openmrs.org/browse/CSM-63
