### PR TITLE
[CSM-76] - Category link reloads the whole page instead of filtering by clicked category

### DIFF
--- a/omod/src/main/webapp/fragments/topArea.gsp
+++ b/omod/src/main/webapp/fragments/topArea.gsp
@@ -32,15 +32,19 @@
 		    return false;
 		});
 		
-		//works for the first time
-		//TODO should work after the second click
-		jq('.select_one_category').click(function (event) {
-		    console.log(jq('.select_one_category'));
-		    jq('.category_check').prop('checked', false);
-		    var id = (this.id).replace("select_", "");
-		    jq("#"+id).prop('checked', true);
-		    submitChartSearchFormWithAjax();
-		    return false;
+		jq("body").on("click", "#inside_filter_categories", function (event) {
+			var currCatLinkId = event.target.id;
+			
+			if(event.target.localName === "a") {
+				var currCatCheckId = currCatLinkId.replace('select_','');
+			
+				jq('#inside_filter_categories').find('input[type=checkbox]:checked').prop('checked', false);;
+			    jq("#" + currCatCheckId).prop('checked', true);
+			    submitChartSearchFormWithAjax();
+				jq('#filter_categories_categories').removeClass('display_filter_onclick');
+				
+				return false;
+			}
 		});
 		
 		jq('#searchBtn').click(function(event) {
@@ -50,6 +54,8 @@
 		
 		jq('#submit_selected_categories').click(function(event) {
 			submitChartSearchFormWithAjax();
+			jq('#filter_categories_categories').removeClass('display_filter_onclick');
+			
 			return false;
 		});
 		
@@ -78,7 +84,7 @@
 		});
 		
 		//Not yet working
-		jq("input[type='checkbox'].category_check").change(function(){
+		/*jq("input[type='checkbox'].category_check").change(function(){
 		    var a = jq("input[type='checkbox'].category_check");
 		    if(a.length == a.filter(":checked").length){
 		        categoryLabel = "All Categories";
@@ -88,7 +94,7 @@
 		    	categoryLabel = "Categories";
 		    }
 		    jq('#category_label').html(categoryLabel);
-		});
+		});*/
 		
 		jq("#chart-previous-searches").click(function(event) {
 			if(jq("#chart-previous-searches-display").is(':visible')) {

--- a/omod/src/main/webapp/resources/scripts/views_factory.js
+++ b/omod/src/main/webapp/resources/scripts/views_factory.js
@@ -949,13 +949,12 @@ function displayCategories(jsonAfterParse) {
 		for (var i = 0; i < jsonAfterParse.facets.length; i++) {
 	        var name = jsonAfterParse.facets[i].facet.name;
 	        var count = jsonAfterParse.facets[i].facet.count;
-	        var displayName = "<div class='category_filter_item'><input class='category_check' id='" + name + "_category' type='checkbox' name='categories' value='" + name;
-	        var displayCount = "<a href='' class='select_one_category' id='select_" + name + "_category'>" + capitalizeFirstLetter(name) + "</a> (" + count + ") </div>";
 	        
-	        if (count == 0) {
-	        	document.getElementById('inside_filter_categories').innerHTML += displayName + "' disabled />" + displayCount;
-	        } else {
-	        	document.getElementById('inside_filter_categories').innerHTML += displayName + "' />" + displayCount;
+	        if (count != 0) {
+		        var displaycheckBox = "<div class='category_filter_item'><input class='category_check' id='" + name + "_category' type='checkbox' name='categories' value='" + name;
+		        var displayDetail = "<a href='' class='select_one_category' id='select_" + name + "_category'>" + capitalizeFirstLetter(name) + "</a> (" + count + ") </div>";
+		        
+		        document.getElementById('inside_filter_categories').innerHTML += displaycheckBox + "' />" + displayDetail;
 	        }
 	    }
 		


### PR DESCRIPTION
Fixed bug in one category link item click.

NOTE:
* If the user clicks a link to filter using one category, it's only this category that shows up, the user needs to click Deselect All and press OK first to reset to all other categories